### PR TITLE
パンくず機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,7 @@ gem 'mini_magick'
 # 2020.11.17追加
 gem 'payjp'
 gem 'dotenv-rails'
+
+# 2020.12.08追加
+gem 'ransack'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.2.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     haml (5.2.0)
       temple (>= 0.8.0)
       tilt
@@ -239,6 +242,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     raindrops (0.19.1)
     rake (13.0.1)
+    ransack (2.4.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -361,6 +368,7 @@ DEPENDENCIES
   factory_bot_rails
   faker (~> 2.8)
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.7)
   jquery-rails
@@ -372,6 +380,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-controller-testing
+  ransack
   rspec-rails (~> 4.0.0.beta2)
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/assets/stylesheets/products/_index.scss
+++ b/app/assets/stylesheets/products/_index.scss
@@ -410,9 +410,7 @@ img {
 }
 
 .productBox {
-  width: 780px;
   margin: 26px auto;
-  display: flex;
   justify-content: space-around;
   &__List {
     width: 220px;

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -111,3 +111,8 @@ select {
 legend {
     color:#000;
 }
+
+a {
+    text-decoration: none;
+    color: #272727;
+  }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_parents
+  before_action :search
   
   private
 
@@ -22,6 +23,11 @@ class ApplicationController < ActionController::Base
 
   def set_parents
     @parents = Category.where(ancestry: nil)
+  end
+  
+  def search
+    @search = Product.ransack(params[:q]) 
+    @search_products = @search.result(distinct: true)
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -52,7 +52,8 @@ class ProductsController < ApplicationController
   end
 
   def search
-    @products = Product.search(params[:keyword])
+    @search = Product.ransack(params[:q]) 
+    @search_products = @search.result
   end
 
   def get_category_children

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,9 @@
 class UsersController < ApplicationController
 
   def show
+    user = User.find(params[:id])
+    @nickname = user.nickname
+    @products = user.products
   end
 
   def edit

--- a/app/views/categories/child.html.haml
+++ b/app/views/categories/child.html.haml
@@ -1,5 +1,13 @@
 = render 'products/topHeader__inner'
 
+- if @category.root?
+  - breadcrumb :parent_category
+- elsif @category.has_children?
+  - breadcrumb :child_category
+- else
+  - breadcrumb :grandchild_category
+= render "layouts/breadcrumbs"
+
 .category__main
   .showMain
     .category__contents
@@ -12,17 +20,18 @@
               %li.catItem_one
                 = link_to "#{child.name}", grandchild_category_path(child.id), class: "itemTitle"
       .productBox
-        -#以下は今後実装
-        -# - @categories_product.each do |product|
-        -#   .productBox__List
-        -#     = link_to product_path(product) do
-        -#       %figure.productBox__img
-        -#         -product.images.each do |image|
-        -#           = image_tag image.url.to_s
-        -#       .productBox__body
-        -#         %p.name
-        -#           = product.name
-        -#         %p.details
-        -#           = product.price
+        - @categories_product.each do |product|
+          .productBox__List
+            = link_to product_path(product) do
+              %figure.productBox__img
+                = image_tag product.images[0].url.url
+              .productBox__body
+                = product.name
+                .details
+                  %ul
+                    %li #{product.price}円
+                    %li
+                      %i.fa.fa-star.likeIcon
+                  %p (税込)
 
 = render 'products/footer'

--- a/app/views/categories/grandchild.html.haml
+++ b/app/views/categories/grandchild.html.haml
@@ -1,5 +1,13 @@
 = render 'products/topHeader__inner'
 
+- if @category.root?
+  - breadcrumb :parent_category
+- elsif @category.has_children?
+  - breadcrumb :child_category
+- else
+  - breadcrumb :grandchild_category
+= render "layouts/breadcrumbs"
+
 .category__main
   .showMain
     .category__contents
@@ -7,17 +15,18 @@
         .catTitle
           = "#{@category.name}の商品一覧"
       .productBox 
-        -#以下は今後実装
-        -# - @category.products.each do |product|
-        -#   .productBox__List
-        -#     = link_to product_path(product) do
-        -#       %figure.productBox__img
-        -#         -product.images.each do |image|
-        -#           = image_tag image.url.to_s
-        -#       .productBox__body
-        -#         %p.name
-        -#           = product.name
-        -#         %p.details
-        -#           = product.price
+        - @category.products.each do |product|
+          .productBox__List
+            = link_to product_path(product) do
+              %figure.productBox__img
+                = image_tag product.images[0].url.url
+              .productBox__body
+                = product.name
+                .details
+                  %ul
+                    %li #{product.price}円
+                    %li
+                      %i.fa.fa-star.likeIcon
+                  %p (税込)
 
 = render 'products/footer'

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,5 +1,8 @@
 = render 'products/topHeader__inner'
 
+- breadcrumb :category_index
+= render "layouts/breadcrumbs"
+
 .category__main
   .showMain
     %h1 カテゴリー一覧

--- a/app/views/categories/parent.html.haml
+++ b/app/views/categories/parent.html.haml
@@ -1,5 +1,13 @@
 = render 'products/topHeader__inner'
 
+- if @category.root?
+  - breadcrumb :parent_category
+- elsif @category.has_children?
+  - breadcrumb :child_category
+- else
+  - breadcrumb :grandchild_category
+= render "layouts/breadcrumbs"
+
 .category__main
   .showMain
     .category__contents
@@ -12,17 +20,19 @@
               %li.catItem_one
                 = link_to "#{child.name}", child_category_path(child), class: "itemTitle"
       .productBox
-        -#以下は今後実装
-        -# - @categories_product.each do |product|
-        -#   .productBox__List
-        -#     = link_to product_path(product) do
-        -#       %figure.productBox__img
-        -#         -product.images.each do |image|
-        -#           = image_tag image.url.to_s
-        -#       .productBox__body
-        -#         %p.name
-        -#           = product.name
-        -#         %p.details
-        -#           = product.price
+        - @categories_product.each do |product|
+          .productBox__List
+            = link_to product_path(product) do
+              %figure.productBox__img
+                = image_tag product.images[0].url.url
+              .productBox__body
+                = product.name
+                .details
+                  %ul
+                    %li #{product.price}円
+                    %li
+                      %i.fa.fa-star.likeIcon
+                  %p (税込)
+        
 
 = render 'products/footer'

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/products/_footer.html.haml
+++ b/app/views/products/_footer.html.haml
@@ -29,10 +29,10 @@
       %h2.footer__content__head FURIMAを見る
       %ul
         %li
-          = link_to root_path do
+          = link_to categories_path do
             カテゴリー一覧
         %li
-          = link_to root_path do
+          = link_to brands_path do
             ブランド一覧
     %li.footer__content
       %h2.footer__content__head ヘルプ＆ガイド

--- a/app/views/products/_topHeader__inner.html.haml
+++ b/app/views/products/_topHeader__inner.html.haml
@@ -4,9 +4,8 @@
       = link_to root_path do
         = image_tag asset_path("logo.png")
     .searchBox
-      = form_with url: search_products_path, method: :get, local: true do |f|
-        %input{name: "utf8", type: "hidden", value: "✓"}/
-        = f.text_field :keyword, placeholder: "キーワードから探す"
+      = search_form_for @search, url: search_products_path do |f|
+        = f.text_field :name_cont, placeholder: "キーワードから探す"
         %button{type: "submit"}
           .searchBox__icon
             = image_tag asset_path("icon-search.png")

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -8,111 +8,105 @@
     
     .search-detail
       .search-detail__title 詳細検索
+      = search_form_for @search, url: search_products_path do |f|
+        .search-detail__keyword
+          .keyword-icon.fas.fa-plus
+          .keyword-text キーワードを追加する
+        = f.text_field :name_cont, placeholder: "例)値下げ", class:"search-detail__keyword--input"
 
-      .search-detail__keyword
-        .keyword-icon.fas.fa-plus
-        .keyword-text キーワードを追加する
-      %input.search-detail__keyword--input{placeholder: "例）値下げ"}
+        .search-detail__category
+          .category-icon.fas.fa-bars
+          .category-text カテゴリーを選択する
+        = f.collection_select :category_id, Category.roots, :id, :name, {include_blank:"---"}, class:'search-detail__category-box', id:'parent_category'
+        .child_category
 
-      .search-detail__category
-        .category-icon.fas.fa-bars
-        .category-text カテゴリーを選択する
-      .search-detail__category-box
-        .search-detail__category-box--select すべて
-        .search-detail__category-box--allow.fas.fa-angle-down
+        .search-detail__brand
+          .brand-icon.fas.fa-tag
+          .brand-text ブランド名から探す
+        = f.text_field :brand, placeholder: "例)シャネル", class:"search-detail__brand--input"
 
-      .search-detail__brand
-        .brand-icon.fas.fa-tag
-        .brand-text ブランド名から探す
-      %input.search-detail__brand--input{placeholder: "例）シャネル"}
+        .search-detail__size
+          .size-icon.fas.fa-expand
+          .size-text サイズを指定する
+        = f.select :size_id, [["すべて", 0],["大きい", 1],["中くらい", 2],["小さい",3]], {}, class: "search-detail__size-box"
 
-      .search-detail__size
-        .size-icon.fas.fa-expand
-        .size-text サイズを指定する
-      .search-detail__size-box
-        .search-detail__size-box--select すべて
-        .search-detail__size-box--allow.fas.fa-angle-down
+        .search-detail__price
+          .price-icon.fas.fa-coins
+          .price-text 価格
+        = f.select :price, [["選択してください", 0],["¥300〜1000", 1],["¥1000〜5000", 2],["¥5000〜10000",3],["¥10000〜30000",4],["¥30000〜50000",5],["¥50000〜",6]], {}, class: "search-detail__price-box"
+        .search-detail__price-input
+          = f.number_field :price_gteq, placeholder: "¥ Min", class:"search-detail__price-input--min" 
+          .search-detail__price-input--middle ~
+          = f.number_field :price_lteq, placeholder: "¥ Max", class:"search-detail__price-input--max" 
 
-      .search-detail__price
-        .price-icon.fas.fa-coins
-        .price-text 価格
-      .search-detail__price-box
-        .search-detail__price-box--select 選択してください
-        .search-detail__price-box--allow.fas.fa-angle-down
-      .search-detail__price-input
-        %input.search-detail__price-input--min{placeholder: "¥ Min"}
-        .search-detail__price-input--middle ~
-        %input.search-detail__price-input--max{placeholder: "¥ Max"}
+        .search-detail__condition
+          .condition-icon.fas.fa-star
+          .condition-text 商品の状態
+        .search-detail__condition-box
+          .condition-select
+            = f.radio_button :status_id_eq, "すべて", class:"condition-select__text"
+            .condition-select__text すべて
+          .condition-select
+            = f.radio_button :status_id_eq, "1", class:"condition-select__text"
+            .condition-select__text 新品、未使用
+          .condition-select
+            = f.radio_button :status_id_eq, "2", class:"condition-select__text"
+            .condition-select__text 未使用に近い
+          .condition-select
+            = f.radio_button :status_id_eq, "3", class:"condition-select__text"
+            .condition-select__text 目立った傷や汚れなし
+          .condition-select
+            = f.radio_button :status_id_eq, "4", class:"condition-select__text"
+            .condition-select__text やや傷や汚れあり
+          .condition-select
+            = f.radio_button :status_id_eq, "5", class:"condition-select__text"
+            .condition-select__text 傷や汚れあり
+          .condition-select
+            = f.radio_button :status_id_eq, "6", class:"condition-select__text"
+            .condition-select__text 全体的に状態が悪い
 
-      .search-detail__condition
-        .condition-icon.fas.fa-star
-        .condition-text 商品の状態
-      .search-detail__condition-box
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text すべて
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text 新品、未使用
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text 未使用に近い
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text 目立った傷や汚れなし
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text やや傷や汚れあり
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text 傷や汚れあり
-        .condition-select
-          .condition-select__checkbox ■
-          .condition-select__text 全体的に状態が悪い
+        .search-detail__delivery
+          .delivery-icon.fas.fa-truck
+          .delivery-text 配送料の負担
+        .search-detail__delivery-box
+          .delivery-select
+            = f.radio_button :cost_eq, "すべて", class:"delivery-select__text"
+            .delivery-select__text すべて
+          .delivery-select
+            = f.radio_button :cost_eq, "着払い(購入者負担)", class:"delivery-select__text"
+            .delivery-select__text 着払い(購入者負担)
+          .delivery-select
+            = f.radio_button :cost_eq, "送料込み(出品者負担)", class:"delivery-select__text"
+            .delivery-select__text 送料込み(出品者負担)
 
-      .search-detail__delivery
-        .delivery-icon.fas.fa-truck
-        .delivery-text 配送料の負担
-      .search-detail__delivery-box
-        .delivery-select
-          .delivery-select__checkbox ■
-          .delivery-select__text すべて
-        .delivery-select
-          .delivery-select__checkbox ■
-          .delivery-select__text 着払い(購入者負担)
-        .delivery-select
-          .delivery-select__checkbox ■
-          .delivery-select__text 送料込み(出品者負担)
+        .search-detail__status
+          .status-icon.fas.fa-shopping-cart
+          .status-text 販売状況
+        .search-detail__status-box
+          .status-select
+            = f.radio_button :judgment_eq, "すべて", class:"status-select__text"
+            .status-select__text すべて
+          .status-select
+            = f.radio_button :judgment_eq, "販売中", class:"status-select__text"
+            .status-select__text 販売中
+          .status-select
+            = f.radio_button :judgment_eq, "売り切れ", class:"status-select__text"
+            .status-select__text 売り切れ
 
-      .search-detail__status
-        .status-icon.fas.fa-shopping-cart
-        .status-text 販売状況
-      .search-detail__status-box
-        .status-select
-          .status-select__checkbox ■
-          .status-select__text すべて
-        .status-select
-          .status-select__checkbox ■
-          .status-select__text 販売中
-        .status-select
-          .status-select__checkbox ■
-          .status-select__text 売り切れ
-
-
-      .search-detail__btn
-        .search-detail__btn--clear クリア
-        .search-detail__btn--enter 完了
+        .search-detail__btn
+          .search-detail__btn--clear クリア
+          -# = reset_tag 'クリア', id: 'js_clear_btn', class:"search-detail__btn--clear"
+          = f.submit "完了", class: "search-detail__btn--enter"
 
   .results
     .titlebox
-      .titlebox__keyword 
-        プログラミング
-      .titlebox__subtext の検索結果
+      .titlebox__subtext 
+        検索結果
 
     .counts 1-132件表示
 
     .items-lists
-      - @products.each do |product|
+      - @search_products.each do |product|
         .productBox__List
           = link_to product_path(product) do
             %figure.productBox__img
@@ -123,19 +117,6 @@
                 = product.name
               %p.details
                 = product.price
-                円
-
-      -# .item-detail
-      -#   .item__img
-      -#     = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-      -#   .item__content
-      -#     .item__title ee
-      -#     .item__price-like
-      -#       .item-price 1000円
-      -#       .item-like
-      -#         .item-like__icon.fa.fa-star.likeIcon
-      -#         .item-like__num 4 
-      -#     .item__tax (税込)
 
 = render 'footer'
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,7 +9,7 @@
         %figure
           = image_tag asset_path("logo.png", alt: "仮画像"), size: "50x50" 
         %h2.bold 
-          umi
+          = @nickname
         %ul.mypage-number
           %li.evaluation 
             評価
@@ -24,76 +24,13 @@
         %text_area 自己紹介文を記入しよう！
       .user-profile
         = link_to "編集する", edit_user_path(current_user), class: "edit"
-        -# = link_to "編集する", class: "edit"
     %h2.item-box-head 
       この出品者の商品
       .items-box-content
         %section.item-box
-          .productBox__List
-            = link_to root_path do
-              %figure.productBox__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/18/beef.JPG"
-              .productBox__body
-                %h3.name テスト
-                .details
-                  %ul
-                    %li 10000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      1
-                  %p (税込)
-          .productBox__List
-            = link_to root_path do
-              %figure.productBox__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG"
-              .productBox__body
-                %h3.name ee
-                .details
-                  %ul
-                    %li 1000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      4
-                  %p (税込)
-          .productBox__List
-            = link_to root_path do
-              %figure.productBox__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-              .productBox__body
-                %h3.name product3
-                .details
-                  %ul
-                    %li 30000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      1
-                  %p (税込)
-          .productBox__List
-            = link_to root_path do
-              %figure.productBox__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
-              .productBox__body
-                %h3.name product2
-                .details
-                  %ul
-                    %li 20000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      0
-                  %p (税込)
-          .productBox__List
-            = link_to root_path do
-              %figure.productBox__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
-              .productBox__body
-                %h3.name product1
-                .details
-                  %ul
-                    %li 10000円
-                    %li
-                      %i.fa.fa-star.likeIcon
-                      1
-                  %p (税込)
+          .productBox
+            = render 'products/product'
+
   = render partial: 'side'
   
 = render 'products/footer'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,30 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :category_index do
+  link "カテゴリー一覧", categories_path
+end
+
+crumb :parent_category do |category|
+  category = Category.find(params[:id]).root
+  link "#{category.name}", parent_category_path(category)
+  parent :category_index
+end
+
+crumb :child_category do |category|
+  category = Category.find(params[:id])
+  if category.has_children?
+    link "#{category.name}", child_category_path(category)
+    parent :parent_category
+  else
+    link "#{category.parent.name}", grandchild_category_path(category)
+    parent :parent_category
+  end
+end
+
+crumb :grandchild_category do |category|
+  category = Category.find(params[:id])
+  link "#{category.name}", grandchild_category_path(category)
+  parent :child_category
+end


### PR DESCRIPTION
What:トップページからカテゴリーそれぞれに対して、パンくず機能を実装した。また、カテゴリー別の商品表示とユーザーマイページの商品表示も実装した。その他、細かい修正をしています。
また、商品検索Lv2も実装していますが、商品購入が未実装のため、実装可能な範囲で実装しています。searchに関するコメントアウトは、今後実装予定です。

Why:カテゴリーのページにおいて、どこのページから遷移したか目に見える状態にするため。